### PR TITLE
fix(ci): restore push trigger to claude-status-check workflow

### DIFF
--- a/.github/workflows/claude-status-check.yml
+++ b/.github/workflows/claude-status-check.yml
@@ -28,6 +28,12 @@
 name: Claude Status Check
 
 on:
+  push:
+    paths:
+      - ".github/workflows/claude-status-check.yml"
+    branches:
+      - main
+
   schedule:
     # Every Monday at 07:00 UTC
     - cron: "0 7 * * 1"
@@ -119,6 +125,7 @@ jobs:
   health-check:
     name: Run Claude health check
     needs: preflight
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     outputs:
       overall_health: ${{ steps.parse.outputs.overall_health }}


### PR DESCRIPTION
## Summary

- Commit `7d39059` removed push path triggers from Claude automation workflows, but `claude-status-check.yml` still receives validation runs on every push that modifies _any_ workflow file
- Without a matching push trigger, these runs fail immediately with "workflow file issue" (0 jobs created, file path shown instead of workflow name)
- Restores the push trigger scoped to `main` branch + the workflow file path only
- The expensive `health-check` job is skipped on push events (`if: github.event_name != 'push'`), so API costs remain zero on config changes

## Test plan

- [ ] After merge, push a trivial change to `claude-status-check.yml` on main — the workflow should run, `preflight` should pass, `health-check` should be skipped
- [ ] Scheduled Monday run and `workflow_dispatch` continue to run all jobs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Restore the push trigger for the Claude status check workflow and ensure costly health checks are skipped on push-triggered runs.

CI:
- Add a push trigger on main for the claude-status-check workflow scoped to its own file.
- Skip the health-check job when the workflow is triggered by a push event to avoid unnecessary API usage.