### PR TITLE
fix(ci): use fromJSON for boolean input in claude-status-check caller

### DIFF
--- a/.github/workflows/claude-status-check.yml
+++ b/.github/workflows/claude-status-check.yml
@@ -50,6 +50,6 @@ jobs:
       pull-requests: read
     secrets: inherit
     with:
-      create_issue: ${{ github.event.inputs.create_issue == 'true' }}
+      create_issue: ${{ fromJSON(github.event.inputs.create_issue || 'false') }}
       max_budget_usd: ${{ github.event.inputs.max_budget_usd || '0.25' }}
       sections: ${{ github.event.inputs.sections || 'all' }}


### PR DESCRIPTION
## Summary

- Replace `${{ github.event.inputs.create_issue == 'true' }}` with `${{ fromJSON(github.event.inputs.create_issue || 'false') }}` in the reusable workflow caller
- GitHub cannot statically validate a comparison expression passed to a `boolean`-typed reusable workflow input, producing "This run likely failed because of a workflow file issue" on every push trigger
- `fromJSON(... || 'false')` is the canonical pattern for forwarding optional boolean inputs from `workflow_dispatch` to a reusable workflow

## Test plan

- [ ] CI passes on this PR branch
- [ ] After merge, confirm `claude-status-check` no longer fails with "workflow file issue" on the push-to-path trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Adjust the create_issue input in the claude-status-check workflow to use fromJSON for proper boolean handling and to avoid GitHub validation warnings.