### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @docdyhr


### PR DESCRIPTION
Assigns @docdyhr as default owner. P1 item from repo audit.

## Summary by Sourcery

Chores:
- Assign @docdyhr as the default code owner for all files via a new CODEOWNERS file.