### PR TITLE
chore(ci): remove schedule triggers from caller workflows

### DIFF
--- a/.github/workflows/claude-dependabot-merge.yml
+++ b/.github/workflows/claude-dependabot-merge.yml
@@ -3,16 +3,13 @@
 # Thin caller that delegates to the reusable workflow in docdyhr/.github.
 # Replaces the previous ~27 KB inline implementation.
 #
+# Schedule is owned by the cross-repo orchestrator in docdyhr/.github.
 # To upgrade the reusable workflow across all consumers, bump the @v1 ref in
 # docdyhr/.github (re-tag) — this caller automatically picks it up on next run.
 
 name: Claude Dependabot Auto-Merge
 
 on:
-  schedule:
-    # Sunday 06:00 UTC — runs before the Monday status check job.
-    - cron: "0 6 * * 0"
-
   push:
     paths:
       - ".github/workflows/claude-dependabot-merge.yml"

--- a/.github/workflows/claude-status-check.yml
+++ b/.github/workflows/claude-status-check.yml
@@ -3,16 +3,13 @@
 # Thin caller that delegates to the reusable workflow in docdyhr/.github.
 # Replaces the previous ~21 KB inline implementation.
 #
+# Schedule is owned by the cross-repo orchestrator in docdyhr/.github.
 # To upgrade the reusable workflow across all consumers, bump the @v1 ref in
 # docdyhr/.github (re-tag) — this caller automatically picks it up on next run.
 
 name: Claude Status Check
 
 on:
-  schedule:
-    # Every Monday at 07:00 UTC
-    - cron: "0 7 * * 1"
-
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary

Phase 5 v2 of the GitHub Repo Maintenance Automation Plan. The cross-repo orchestrator in `docdyhr/.github` now owns all scheduling (Sunday dependabot triage, Monday status check). Per-repo `schedule:` triggers are redundant and fire a duplicate Claude API session each week.

**Removed from both callers:**
- `claude-dependabot-merge.yml`: `schedule: cron "0 6 * * 0"`
- `claude-status-check.yml`: `schedule: cron "0 7 * * 1"`

`workflow_dispatch` and `push` triggers are preserved — manual and file-change-triggered runs still work normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Remove weekly cron schedule triggers from claude-dependabot-merge and claude-status-check workflows while preserving push and manual triggers.